### PR TITLE
Run unit tests in ci as well

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,8 +1,10 @@
 name: publish to nuget
+
 on:
   push:
-    branches:
-      - master
+    branches: [master, develop]
+  pull_request: {}
+
 env:
   VERSION_FILE_PATH: src/Directory.Build.props
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
@@ -22,6 +24,7 @@ jobs:
         run: dotnet test
 
       - name: publish FairyBread on version change
+        if: github.ref != 'refs/heads/master'
         uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/FairyBread/FairyBread.csproj

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,13 +7,20 @@ env:
   VERSION_FILE_PATH: src/Directory.Build.props
   NUGET_KEY: ${{ secrets.NUGET_KEY }}
   TAG_COMMIT: false
-jobs: 
+jobs:
   publish:
     name: list on nuget
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2      
-        
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: "3.1.x" # Will install the latest in the 3.1 channel
+
+      - name: run unit tests
+        run: dotnet test
+
       - name: publish FairyBread on version change
         uses: rohith/publish-nuget@v2
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,7 @@ jobs:
         run: dotnet test
 
       - name: publish FairyBread on version change
-        if: github.ref != 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: rohith/publish-nuget@v2
         with:
           PROJECT_FILE_PATH: src/FairyBread/FairyBread.csproj


### PR DESCRIPTION
This PR aims to run the unit tests on the ci, it also introduces:

- Running unit tests on all PR's
- Running the publish only on master push events

---

Worth mentioning that "workflow" config will only allow "People with write or admin permissions to a repository can create, edit, or view workflows.". So you'd need to _import_ this into your repo to test this new workflow.