### PR TITLE
Drop .NET Core 2 "official" support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,10 +22,6 @@ jobs:
 
       - uses: actions/setup-dotnet@v1.7.2
         with:
-          dotnet-version: "2.2.x"
-
-      - uses: actions/setup-dotnet@v1.7.2
-        with:
           dotnet-version: "3.1.x"
 
       - uses: actions/setup-dotnet@v1.7.2

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -23,6 +23,6 @@
     <HotChocolateVersion>12.4.0</HotChocolateVersion>
 
     <LibraryTargetFrameworks>net5.0; netcoreapp3.1; netstandard2.0</LibraryTargetFrameworks>
-    <TestTargetFrameworks>net5.0; netcoreapp3.1; netcoreapp2.1</TestTargetFrameworks>
+    <TestTargetFrameworks>net5.0; netcoreapp3.1</TestTargetFrameworks>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
It's now reached EOL. https://devblogs.microsoft.com/dotnet/net-core-2-1-will-reach-end-of-support-on-august-21-2021/

Note this drop is just in running tests as part of the build, as technically it's still supported via a netstandard2.0 targeted build of the package. It's just that isn't "officially" supported anymore.