### PR TITLE
Upgrade to HC 13.0.0-preview.88 due to breaking changes

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     <Version>10.0.0-preview.1</Version>
 
     <FluentValidationVersion>10.0.0</FluentValidationVersion>
-    <HotChocolateVersion>13.0.0-preview.68</HotChocolateVersion>
+    <HotChocolateVersion>13.0.0-preview.88</HotChocolateVersion>
 
     <LibraryTargetFrameworks>net7.0; net6.0; netstandard2.0</LibraryTargetFrameworks>
     <TestTargetFrameworks>net7.0; net6.0</TestTargetFrameworks>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -17,7 +17,7 @@
     <PackageIconUrl>https://github.com/benmccallum/fairybread/raw/master/logo-400x400.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/benmccallum/fairybread/blob/master/LICENSE</PackageLicenseUrl>
 
-    <Version>10.0.0-preview.1</Version>
+    <Version>10.0.0-preview.2</Version>
 
     <FluentValidationVersion>10.0.0</FluentValidationVersion>
     <HotChocolateVersion>13.0.0-preview.88</HotChocolateVersion>

--- a/src/FairyBread.Tests/CustomizationTests.CustomValidatorProvider_Works.verified.txt
+++ b/src/FairyBread.Tests/CustomizationTests.CustomValidatorProvider_Works.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Doesnt_Call_Field_Resolver_If_Invalid.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Doesnt_Call_Field_Resolver_If_Invalid.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: someResolver,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Multi_TopLevelFields_And_MultiRuns_Works.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Multi_TopLevelFields_And_MultiRuns_Works.verified.txt
@@ -7,7 +7,7 @@
         Path: {
           Name: read,
           Parent: {
-            Depth: -1,
+            Length: -1,
             IsRoot: true
           },
           IsRoot: false
@@ -39,7 +39,7 @@
         Path: {
           Name: read,
           Parent: {
-            Depth: -1,
+            Length: -1,
             IsRoot: true
           },
           IsRoot: false
@@ -71,7 +71,7 @@
         Path: {
           Name: read,
           Parent: {
-            Depth: -1,
+            Length: -1,
             IsRoot: true
           },
           IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=2.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=2.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: write,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=3.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=3.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: write,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=4.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Mutation_Works_caseData=4.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: write,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -34,7 +34,7 @@
       Path: {
         Name: write,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -62,7 +62,7 @@
       Path: {
         Name: write,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=4.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=4.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithArrayArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=5.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=5.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithArrayArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=6.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Array_Works_caseData=6.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithArrayArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -35,7 +35,7 @@
       Path: {
         Name: readWithArrayArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=4.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=4.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithListArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=5.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=5.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithListArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=6.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_List_Works_caseData=6.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithListArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -35,7 +35,7 @@
       Path: {
         Name: readWithListArg,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=2.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=2.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=3.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=3.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=4.verified.txt
+++ b/src/FairyBread.Tests/GeneralTests.Query_Works_caseData=4.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -34,7 +34,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -62,7 +62,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/InjectorTests.Should_Respect_ExplicitValidationAttributes_valid=False.verified.txt
+++ b/src/FairyBread.Tests/InjectorTests.Should_Respect_ExplicitValidationAttributes_valid=False.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -33,7 +33,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -60,7 +60,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -86,7 +86,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -112,7 +112,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -140,7 +140,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -168,7 +168,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -194,7 +194,7 @@
       Path: {
         Name: readWithExplicitValidation,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/InjectorTests.Should_Respect_ExplicitValidationFluent_valid=False.verified.txt
+++ b/src/FairyBread.Tests/InjectorTests.Should_Respect_ExplicitValidationFluent_valid=False.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -33,7 +33,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -60,7 +60,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -87,7 +87,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -113,7 +113,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -139,7 +139,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -167,7 +167,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -195,7 +195,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -221,7 +221,7 @@
       Path: {
         Name: readWithExplicitValidationFluent,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/InjectorTests.Works_registerValidators=True.verified.txt
+++ b/src/FairyBread.Tests/InjectorTests.Works_registerValidators=True.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: scalarArgsA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -31,7 +31,7 @@
       Path: {
         Name: objectArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -57,7 +57,7 @@
       Path: {
         Name: objectArgD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -83,7 +83,7 @@
       Path: {
         Name: objectArgD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -109,7 +109,7 @@
       Path: {
         Name: arrayArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -138,7 +138,7 @@
       Path: {
         Name: arrayArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -167,7 +167,7 @@
       Path: {
         Name: listArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -196,7 +196,7 @@
       Path: {
         Name: listArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -225,7 +225,7 @@
       Path: {
         Name: listArgB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -254,7 +254,7 @@
       Path: {
         Name: listArgB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -283,7 +283,7 @@
       Path: {
         Name: listArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -312,7 +312,7 @@
       Path: {
         Name: listArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -341,7 +341,7 @@
       Path: {
         Name: listArgD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -370,7 +370,7 @@
       Path: {
         Name: listArgD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -399,7 +399,7 @@
       Path: {
         Name: listOfListArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -428,7 +428,7 @@
       Path: {
         Name: listOfListArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -457,7 +457,7 @@
       Path: {
         Name: objectArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -483,7 +483,7 @@
       Path: {
         Name: objectArgB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -509,7 +509,7 @@
       Path: {
         Name: objectArgB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -535,7 +535,7 @@
       Path: {
         Name: objectArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -561,7 +561,7 @@
       Path: {
         Name: scalarArgsA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -586,7 +586,7 @@
       Path: {
         Name: scalarArgsB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -611,7 +611,7 @@
       Path: {
         Name: scalarArgsB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -636,7 +636,7 @@
       Path: {
         Name: scalarArgsC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -661,7 +661,7 @@
       Path: {
         Name: scalarArgsC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -686,7 +686,7 @@
       Path: {
         Name: scalarArgsD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -711,7 +711,7 @@
       Path: {
         Name: scalarArgsD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -736,7 +736,7 @@
       Path: {
         Name: listOfListArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -765,7 +765,7 @@
       Path: {
         Name: nullableScalarArgsA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -792,7 +792,7 @@
       Path: {
         Name: nullableScalarArgsB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -819,7 +819,7 @@
       Path: {
         Name: nullableScalarArgsB,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -846,7 +846,7 @@
       Path: {
         Name: nullableScalarArgsC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -873,7 +873,7 @@
       Path: {
         Name: nullableScalarArgsC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -900,7 +900,7 @@
       Path: {
         Name: nullableScalarArgsD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -927,7 +927,7 @@
       Path: {
         Name: nullableScalarArgsD,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -954,7 +954,7 @@
       Path: {
         Name: objectArgA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -980,7 +980,7 @@
       Path: {
         Name: nullableScalarArgsA,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -1007,7 +1007,7 @@
       Path: {
         Name: listOfListArgC,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/RequiresOwnScopeValidatorTests.OwnScopes_Are_Disposed.verified.txt
+++ b/src/FairyBread.Tests/RequiresOwnScopeValidatorTests.OwnScopes_Are_Disposed.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false

--- a/src/FairyBread.Tests/RequiresOwnScopeValidatorTests.OwnScopes_Work.verified.txt
+++ b/src/FairyBread.Tests/RequiresOwnScopeValidatorTests.OwnScopes_Work.verified.txt
@@ -6,7 +6,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -34,7 +34,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -62,7 +62,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false
@@ -90,7 +90,7 @@
       Path: {
         Name: read,
         Parent: {
-          Depth: -1,
+          Length: -1,
           IsRoot: true
         },
         IsRoot: false


### PR DESCRIPTION
A change introduced to HC [13.0.0-preview.82](https://github.com/ChilliCream/hotchocolate/releases/tag/13.0.0-preview.82) is breaking `AddFairyBread` with the error `Error CS7069: Reference to type 'IRequestExecutorBuilder' claims it is defined in 'HotChocolate.Execution', but it could not be found`. 