### PR TITLE
Support HotChocolate-15.1.

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -21,9 +21,9 @@
     <Version>11.0.0</Version>
 
     <FluentValidationVersion>10.0.0</FluentValidationVersion>
-    <HotChocolateVersion>14.0.0</HotChocolateVersion>
+    <HotChocolateVersion>15.1.3</HotChocolateVersion>
 
-    <LibraryTargetFrameworks>net7.0; net6.0; netstandard2.0</LibraryTargetFrameworks>
-    <TestTargetFrameworks>net7.0; net6.0</TestTargetFrameworks>
+    <LibraryTargetFrameworks>net8.0; net9.0</LibraryTargetFrameworks>
+    <TestTargetFrameworks>net8.0; net9.0</TestTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -18,7 +18,7 @@
     <PackageIconUrl>https://github.com/benmccallum/fairybread/raw/master/logo-400x400.png</PackageIconUrl>
     <PackageLicenseUrl>https://github.com/benmccallum/fairybread/blob/master/LICENSE</PackageLicenseUrl>
 
-    <Version>11.0.0</Version>
+    <Version>12.0.0-rc.1</Version>
 
     <FluentValidationVersion>10.0.0</FluentValidationVersion>
     <HotChocolateVersion>15.1.3</HotChocolateVersion>


### PR DESCRIPTION
Hotchocolate 15.1 requires the use of net8.0 and net9.0. Older versions of netcore have been obsoleted.